### PR TITLE
Add method to clear command list from Tx channel

### DIFF
--- a/nanoFramework.Hardware.Esp32.Rmt/TransmitterChannel.cs
+++ b/nanoFramework.Hardware.Esp32.Rmt/TransmitterChannel.cs
@@ -326,6 +326,14 @@ namespace nanoFramework.Hardware.Esp32.Rmt
         private uint WaitTxDone(int waitTime) =>
             NativeWaitTxDone(waitTime);
 
+        /// <summary>
+        /// Clear list of commands.
+        /// </summary>
+        public void ClearCommands()
+        {
+            _commands.Clear();
+        }
+
         #endregion Methods
 
         #region native calls


### PR DESCRIPTION
## Description
- Add method to clear command list from Tx channel.

## Motivation and Context
- Provide a way to clear the command list without having to recreate the Tx channel object.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [x] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
