### PR TITLE
Add source clock frequency property

### DIFF
--- a/nanoFramework.Hardware.Esp32.Rmt.sln
+++ b/nanoFramework.Hardware.Esp32.Rmt.sln
@@ -5,6 +5,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{20F57A1F-AF70-401A-94F7-A2F940271F7D}"
 	ProjectSection(SolutionItems) = preProject
 		NuGet.Config = NuGet.Config
+		README.md = README.md
 		version.json = version.json
 	EndProjectSection
 EndProject

--- a/nanoFramework.Hardware.Esp32.Rmt/Properties/AssemblyInfo.cs
+++ b/nanoFramework.Hardware.Esp32.Rmt/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.0.4.0")]
+[assembly: AssemblyNativeVersion("100.0.5.0")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/nanoFramework.Hardware.Esp32.Rmt/RmtChannel.cs
+++ b/nanoFramework.Hardware.Esp32.Rmt/RmtChannel.cs
@@ -47,19 +47,29 @@ namespace nanoFramework.Hardware.Esp32.Rmt
         }
 
         /// <summary>
-        /// Gets the source clock. Only the 80MHz APB clock is currently supported so the value will always be <see cref="SourceClock.APB"/> in the current implementation.
+        /// Gets the source clock type. 
+        /// This is currently fixed to use APB clock so will always be <see cref="SourceClock.APB"/> in the current implementation.
         /// </summary>
         /// <remarks>
-        /// ESP IDF v4.4.3 supports only <see cref="SourceClock.APB"/>. This property cannot be changed.
+        /// ESP IDF v5.1.4 supports only <see cref="SourceClock.APB"/> for ESP32. This property cannot be changed.
         /// </remarks>
         /// <exception cref="NotSupportedException"></exception>
-        public SourceClock SourceClock
+        public static SourceClock SourceClock
         {
             get => SourceClock.APB;
         }
 
         /// <summary>
-        /// The value can be between 1 and 255.
+        /// Returns the actual frequency of the source clock used by the hardware when clock source is set to default. 
+        /// This is currently 80Mhz for all devices except ESP32_H2 which is 32Mhz. This should be used to calculate timings on rmtChannel.
+        /// </summary>
+        public static int SourceClockFrequency
+        {
+            get => NativeGetSourceClockFrequency();
+        }
+
+        /// <summary>
+        /// The value can be between 1 and 255 and affects all RMT channels.
         /// </summary>
         public byte ClockDivider
         {
@@ -112,6 +122,9 @@ namespace nanoFramework.Hardware.Esp32.Rmt
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void NativeSetNumberOfMemoryBlocks(byte value);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern int NativeGetSourceClockFrequency();
 
         #endregion native calls
     }


### PR DESCRIPTION
## Description

Due to ESP32_H2 having a different default clock frequency added the current source frequency as a static property to rmtChannel.

This can be used to calculate timings instead of hard coding the 80Mhz in applications.

Backwards compatible. 


## Motivation and Context

- RMT not working on ESP32_H2


## How Has This Been Tested?<!-- (IF APPLICABLE) -->


## Screenshots<!-- (IF APPROPRIATE): -->

Locally with modified CCSWE.nanoFramework.NeoPixel 

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
