### PR TITLE
`RmtCommandSerializer` type is now included in the assembly

### DIFF
--- a/nanoFramework.Hardware.Esp32.Rmt/RmtCommandSerializer.cs
+++ b/nanoFramework.Hardware.Esp32.Rmt/RmtCommandSerializer.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 #nullable enable
 namespace nanoFramework.Hardware.Esp32.Rmt
 {
-    [ExcludeType]
     internal static class RmtCommandSerializer
     {
         /// <summary>


### PR DESCRIPTION
## Description
- Remove excludetype attrib.

## Motivation and Context
- This type is required.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests locally with an updated ESP32_S3 firmware.
![image](https://github.com/user-attachments/assets/bf5c5dc7-2820-40d4-ab9a-d1f4cd2be4ba)

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
